### PR TITLE
Modify the release.sh to generate ARM64 release

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -14,6 +14,7 @@ function build() {
   os=$1
   arch=$2
 
+  extension=''
   if [ "${os}" == 'windows' ]
   then
     extension='.exe'
@@ -41,3 +42,4 @@ for os in darwin linux windows
 do
   build "${os}" amd64
 done
+build linux arm64


### PR DESCRIPTION
This change modified the release.sh script to support release including arm64 binary.